### PR TITLE
Update meta.yaml to 1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cifkit" %}
-{%- set version = "1.0.4" -%}
+{%- set version = "1.0.1" -%}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0ddb5d97a5d784d4f8c161a53ccceab72d0f8c1016c393b71b38d286f1f9a72f
+  sha256: eea2047c316681f009c433c1657a77728dddb8a02168355baaed867211bbbf3a
 
 build:
   noarch: python


### PR DESCRIPTION
Updated meta.yaml to version 1.0.1 with SHA value of eea2047c316681f009c433c1657a77728dddb8a02168355baaed867211bbbf3a